### PR TITLE
Fix for upload_tmp_dir test

### DIFF
--- a/PhpSecInfo/Test/Core/upload_tmp_dir.php
+++ b/PhpSecInfo/Test/Core/upload_tmp_dir.php
@@ -71,7 +71,7 @@ class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
         if ($perms === false) {
             return PHPSECINFO_TEST_RESULT_WARN;
         } else if ($this->current_value
-            && !preg_match("|" . PHPSECINFO_TEST_COMMON_TMPDIR . "/?|", $this->current_value)
+            && !preg_match("%^" . PHPSECINFO_TEST_COMMON_TMPDIR . "(/|$)%", $this->current_value)
             && !($perms & 0x0004)
             && !($perms & 0x0002)
         ) {


### PR DESCRIPTION
Previously, it was checking for any path which contained the string "/tmp", which meant that paths like "/srv/piwik/tmp_upload" were marked as insecure. This change makes it so that the path is only considered insecure if it *begins* with `/tmp` (that is, the shared temp directory).
