### PR TITLE
fix: broken "learn more" link on index view

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -6,7 +6,7 @@
 <div piwik-content-intro>
     <h2>{{ title }}</h2>
     <p>{{ 'SecurityInfo_PluginDescription'|translate }}</p>
-    <p>Learn more: read our guide <a rel='noreferrer' target='_blank' href='https://piwik.org/security/how-to-secure-piwik/'>Hardening Piwik: How to make Piwik and your web server
+    <p>Learn more: read our guide <a rel='noreferrer' target='_blank' href='https://matomo.org/docs/security/'>Hardening Piwik: How to make Piwik and your web server
             more secure?</a></p>
 
     <p class="alert-info alert">Did you know?


### PR DESCRIPTION
As this was already reported as an issue in #29 and this is a very prominently link displayed in the upper content block of the view, this should be fixed with higher priority.

There are still plenty of occurrences of "Piwik" and other URLs to 'piwik.org' still. I didn't bother to fix as there is #26 and the fix for other occurrences should be decided upstream IMHO.

Closes #29.