### PR TITLE
Fix missing key warning

### DIFF
--- a/PhpSecInfo/Test/Test_Application.php
+++ b/PhpSecInfo/Test/Test_Application.php
@@ -44,6 +44,7 @@ class PhpSecInfo_Test_Application extends PhpSecInfo_Test
     {
         $urls = array(
             'Piwik' => 'http://piwik.org/changelog',
+            'Matomo' => 'http://piwik.org/changelog',
             'PHP'   => 'http://php.net/',
         );
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "SecurityInfo",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "description": "Provides security information about your PHP environment and offers suggestions based on PhpSecInfo from the PHP Security Consortium.",
     "keywords": ["security","phpsec"],
     "license": "GPL v3+",


### PR DESCRIPTION
### Description:

While testing for PHP 8.3 compatibility, I noticed the following warning in the UI:
```
WARNING: /plugins/SecurityInfo/PhpSecInfo/Test/Test_Application.php(51): Warning - Undefined array key &quot;Matomo&quot; - Matomo 5.0.0-rc8 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) (Module: SecurityInfo, Action: index, In CLI mode: false)
```
This PR is to address that warning.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
