### PR TITLE
Adds code to load test files only via an allowlist, #AS-657

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+5.0.5 - 2026-08-06
+- Added code to load test files only via an allowlist
+
 5.0.4 - 2025-01-20
 - Added missing license file
 

--- a/PhpSecInfo/PhpSecInfo.php
+++ b/PhpSecInfo/PhpSecInfo.php
@@ -217,36 +217,65 @@ class PhpSecInfo
 
 
     /**
-     * recurses through the Test subdir and includes classes in each test group subdir,
-     * then builds an array of classnames for the tests that will be run
+     * The tests shipped by this plugin, grouped by their Test/ subdirectory.
+     *
+     * loadTests() only ever includes files named in this list. The directory is
+     * deliberately NOT scanned: an attacker able to write into Test/<group>/ must
+     * not be able to have an arbitrary file executed as PHP simply by dropping it
+     * there (regardless of its name or extension).
+     *
+     * @var array<string, string[]>
+     */
+    private static $shippedTests = array(
+        'Application' => array('php', 'piwik'),
+        'CGI'         => array('force_redirect'),
+        'Core'        => array(
+            'allow_url_fopen',
+            'allow_url_include',
+            'display_errors',
+            'expose_php',
+            'file_uploads',
+            'gid',
+            'magic_quotes_gpc',
+            'memory_limit',
+            'open_basedir',
+            'post_max_size',
+            'register_globals',
+            'uid',
+            'upload_max_filesize',
+            'upload_tmp_dir',
+        ),
+        'Curl'        => array('file_support'),
+        'Session'     => array('save_path', 'use_trans_sid'),
+    );
+
+    /**
+     * Includes the test classes shipped by this plugin and builds the array of
+     * classnames for the tests that will be run.
+     *
+     * Only the files enumerated in self::$shippedTests are loaded; the Test/
+     * directories are never listed, so no file that happens to be present on disk
+     * is included unless this plugin ships it under that exact name.
      */
     public function loadTests()
     {
+        $testRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Test';
 
-        $test_root = dir(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Test');
+        $classNames = array();
 
-        //echo "<pre>"; echo print_r($test_root, true); echo "</pre>";
+        foreach (self::$shippedTests as $testDir => $testFiles) {
+            foreach ($testFiles as $testFile) {
+                $path = $testRoot . DIRECTORY_SEPARATOR . $testDir . DIRECTORY_SEPARATOR . $testFile . '.php';
 
-        while (false !== ($entry = $test_root->read())) {
-            if (is_dir($test_root->path . DIRECTORY_SEPARATOR . $entry) && !preg_match('~^(\.|_vti)(.*)$~', $entry)) {
-                $test_dirs[] = $entry;
-            }
-        }
-        //echo "<pre>"; echo print_r($test_dirs, true); echo "</pre>";
-
-        // include_once all files in each test dir
-        foreach ($test_dirs as $test_dir) {
-            $this_dir = dir($test_root->path . DIRECTORY_SEPARATOR . $test_dir);
-
-            while (false !== ($entry = $this_dir->read())) {
-                if (!is_dir($this_dir->path . DIRECTORY_SEPARATOR . $entry)) {
-                    include_once $this_dir->path . DIRECTORY_SEPARATOR . $entry;
-                    $classNames[] = "PhpSecInfo_Test_" . $test_dir . "_" . basename($entry, '.php');
+                if (!is_file($path)) {
+                    continue;
                 }
+
+                include_once $path;
+                $classNames[] = "PhpSecInfo_Test_" . $testDir . "_" . $testFile;
             }
         }
 
-        // modded this to not throw a PHP5 STRICT notice, although I don't like passing by value here
         $this->tests_to_run = $classNames;
     }
 

--- a/PhpSecInfo/PhpSecInfo.php
+++ b/PhpSecInfo/PhpSecInfo.php
@@ -220,9 +220,7 @@ class PhpSecInfo
      * The tests shipped by this plugin, grouped by their Test/ subdirectory.
      *
      * loadTests() only ever includes files named in this list. The directory is
-     * deliberately NOT scanned: an attacker able to write into Test/<group>/ must
-     * not be able to have an arbitrary file executed as PHP simply by dropping it
-     * there (regardless of its name or extension).
+     * deliberately NOT scanned, new test files should be added here exclusively
      *
      * @var array<string, string[]>
      */

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "SecurityInfo",
-    "version": "5.0.4",
+    "version": "5.0.5",
     "description": "Provides security information about your PHP environment and offers suggestions based on PhpSecInfo from the PHP Security Consortium.",
     "keywords": ["security","phpsec"],
     "license": "GPL v3+",

--- a/tests/System/PhpSecInfoShippedTestsTest.php
+++ b/tests/System/PhpSecInfoShippedTestsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SecurityInfo\tests\System;
+
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+class PhpSecInfoShippedTestsTest extends SystemTestCase
+{
+    public function testShippedTestsAllowlistMatchesShippedTestFiles()
+    {
+        require_once PIWIK_INCLUDE_PATH . '/plugins/SecurityInfo/PhpSecInfo/PhpSecInfo.php';
+
+        $reflection = new \ReflectionClass('PhpSecInfo');
+        $property = $reflection->getProperty('shippedTests');
+        $property->setAccessible(true);
+
+        $configuredFiles = array();
+        foreach ($property->getValue() as $testGroup => $testFiles) {
+            foreach ($testFiles as $testFile) {
+                $configuredFiles[] = $testGroup . '/' . $testFile . '.php';
+            }
+        }
+
+        sort($configuredFiles);
+
+        $testRoot = PIWIK_INCLUDE_PATH . '/plugins/SecurityInfo/PhpSecInfo/Test';
+        $actualFiles = glob($testRoot . '/*/*.php');
+        $actualFiles = array_map(function ($path) use ($testRoot) {
+            return str_replace($testRoot . '/', '', $path);
+        }, $actualFiles ?: array());
+
+        sort($actualFiles);
+
+        $this->assertNotEmpty($configuredFiles);
+        $this->assertSame($actualFiles, $configuredFiles);
+    }
+}

--- a/tests/Unit/PhpSecInfoShippedTestsTest.php
+++ b/tests/Unit/PhpSecInfoShippedTestsTest.php
@@ -7,11 +7,11 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\SecurityInfo\tests\System;
+namespace Piwik\Plugins\SecurityInfo\tests\Unit;
 
-use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
 
-class PhpSecInfoShippedTestsTest extends SystemTestCase
+class PhpSecInfoShippedTestsTest extends UnitTestCase
 {
     public function testShippedTestsAllowlistMatchesShippedTestFiles()
     {


### PR DESCRIPTION
## Description
Adds code to load test files only via an allowlist, #AS-657

## Issue No
#AS-657

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
